### PR TITLE
BUG: Add missing #include <iostream> to C++ files using cerr/endl

### DIFF
--- a/LinesIntersection/Logic/Testing/Cxx/vtkSlicerLinesIntersectionLogicTest1.cxx
+++ b/LinesIntersection/Logic/Testing/Cxx/vtkSlicerLinesIntersectionLogicTest1.cxx
@@ -21,6 +21,7 @@
 
 // STL includes
 #include <fstream>
+#include <iostream>
 #include <limits>
 
 // OS includes

--- a/PointToLineRegistration/Logic/Testing/Cxx/vtkSlicerPointToLineRegistrationLogicTest1.cxx
+++ b/PointToLineRegistration/Logic/Testing/Cxx/vtkSlicerPointToLineRegistrationLogicTest1.cxx
@@ -20,6 +20,7 @@
 
 // STL includes
 #include <fstream>
+#include <iostream>
 #include <limits>
 
 // OS includes

--- a/PointToLineRegistration/Logic/vtkPointToLineRegistration.cpp
+++ b/PointToLineRegistration/Logic/vtkPointToLineRegistration.cpp
@@ -38,6 +38,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <vtkeigen/eigen/Dense>
 #include <vtkeigen/eigen/SVD>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 
 namespace


### PR DESCRIPTION
Three files used std::cerr, std::endl, and ostream without an explicit #include <iostream>, relying on transitive includes that may not always be present.

See: https://discourse.vtk.org/t/important-update-standard-iostream-availability-from-vtk/16171